### PR TITLE
test: システムテスト用ブランチを作成し、DBマウント解除

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,5 @@ services:
       MYSQL_DATABASE: internalbooks
       MYSQL_INIT_CONNECT: "SET NAMES utf8mb4;"
     volumes:
-      - ./mysql/data:/var/lib/mysql  # データ永続化    # 本番環境ではマウントする
+    #  - ./mysql/data:/var/lib/mysql  # データ永続化    # 本番環境ではマウントする
       - ./mysql/init-sql:/docker-entrypoint-initdb.d  # 初回実行SQL


### PR DESCRIPTION
# 概要
システムテスト用のブランチを作成し、DBマウントを解除

## 作業内容
- システムテスト用ブランチを作成
- DBマウントの設定を解除

## 変更理由
- システムテスト環境ではDBマウントは効率が悪く不要なため

## 確認事項
- DBマウント無しで正常に動作することを確認
- 既存機能に影響がないことを確認

## 備考
- テスト完了後は本ブランチを削除予定