### PR TITLE
fix: SearchResultの借りる/返すポップアップの表示を修正

### DIFF
--- a/InternalBooks/src/main/resources/templates/page/SearchResult.html
+++ b/InternalBooks/src/main/resources/templates/page/SearchResult.html
@@ -60,7 +60,8 @@
       </div>
 
 	  <!--借りる際のウィンドウ-->
-	  	<div id="b-confirmation" class="col-6 pt-3 position-fixed top-50" style="display: none; z-index: 999;">
+	  	<div id="b-confirmation" class="col-11 col-sm-6 pt-3 position-fixed"
+		 style="display: none; z-index: 999; transform: translate(-50%, -50%); top: 50%; left: 50%;">
 	  		<p class="text-center mt-5" style="font-size: 20px;">この書籍を借りますか？</p>
 	  		 <div class="d-flex h-25">
 
@@ -83,7 +84,8 @@
 
 
 	  	<!--返す際のウィンドウ-->
-	  	<div id="r-confirmation" class="col-6 pt-3 position-fixed top-50" style="display: none; z-index: 999;">
+	  	<div id="r-confirmation" class="col-11 col-sm-6 pt-3 position-fixed"
+		 style="display: none; z-index: 999; transform: translate(-50%, -50%); top: 50%; left: 50%;">
 	  		<p class="text-center mt-5 mb-5" style="font-size: 20px;">この書籍を返却しますか？</p>
 	  		<div class="d-flex h-25">
 				<form id="return-form-modal" method="post" th:action="@{/page/ReturnCompleted}"
@@ -159,7 +161,7 @@
 		<div th:if="${book.status != '貸出中'}">
 		  <form method="post" th:action="@{/遷移先書いてください}" class="d-inline">
 		    <input type="hidden" name="bookId" th:value="${book.bookId}"/>
-		    <button id="bc" type="button" class="btn btn-lg col-5 col-sm-4 shadow" style="color: #47B78A">
+		    <button id="bc" type="button" class="btn btn-lg col-5 col-sm-4 shadow" style="color: #47B78A; font-size: 18px">
 		      借りる
 		    </button>
 		  </form>


### PR DESCRIPTION
# 概要
- SearchResultの借りる/返すポップアップの表示を修正

## 作業内容
- htmlの借りる/返すウィンドウのレスポンシブ対応を修正

# 変更理由
- 経営層レビューでの指摘修正

## 確認事項
- [ ] 借りるボタンを押下した後に表示されるポップアップが表示崩れなく表示されること
- [ ] 返すボタンを押下した後に表示されるポップアップが表示崩れなく表示されること

## 備考
- 特になし