### PR TITLE
fix: バグチケットinc22の修正およびSearchRusultのボタンのフォントサイズ統一

### DIFF
--- a/InternalBooks/src/main/java/com/example/internalbooks/controller/AdminController.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/controller/AdminController.java
@@ -7,8 +7,6 @@ import jakarta.validation.Valid;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -25,16 +23,15 @@ import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import com.example.internalbooks.service.TUserService;
-
+import com.example.internalbooks.common.Const;
 import com.example.internalbooks.dto.DtoBookInfo;
 import com.example.internalbooks.dto.DtoUserEdit;
 import com.example.internalbooks.dto.DtoUserRegistration;
 import com.example.internalbooks.entity.MDepartmentEntity;
 import com.example.internalbooks.entity.TUserEntity;
-import com.example.internalbooks.common.Const;
 import com.example.internalbooks.service.AuthService;
 import com.example.internalbooks.service.TBookService;
+import com.example.internalbooks.service.TUserService;
 import com.example.internalbooks.utils.JwtUtil;
 
 /**

--- a/InternalBooks/src/main/java/com/example/internalbooks/controller/InternalBooksController.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/controller/InternalBooksController.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
-import lombok.extern.slf4j.Slf4j;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +29,8 @@ import com.example.internalbooks.service.AuthService;
 import com.example.internalbooks.service.TBookService;
 import com.example.internalbooks.service.TLendingHistoryService;
 import com.example.internalbooks.utils.JwtUtil;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Controller
 @Slf4j
@@ -449,7 +450,7 @@ public class InternalBooksController {
                 }
                 model.addAttribute("hasReviewHistory", hasReviewHistory);
                 
-                return "page/searchresult";
+                return "page/SearchResult";
             }
 
             // DBへ(userId,name,mailAddress,password,departmentId)を保存

--- a/InternalBooks/src/main/java/com/example/internalbooks/service/AuthService.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/service/AuthService.java
@@ -1,7 +1,5 @@
 package com.example.internalbooks.service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.AuthenticationException;

--- a/InternalBooks/src/main/resources/templates/page/SearchResult.html
+++ b/InternalBooks/src/main/resources/templates/page/SearchResult.html
@@ -64,7 +64,6 @@
 		 style="display: none; z-index: 999; transform: translate(-50%, -50%); top: 50%; left: 50%;">
 	  		<p class="text-center mt-5" style="font-size: 20px;">この書籍を借りますか？</p>
 	  		 <div class="d-flex h-25">
-
 				<form id="lending-form-modal" method="post" th:action="@{/page/LendingCompleted}"
 				th:object= "${tlend}" class="d-flex w-50 border-0 align-items-center justify-content-center"
 				style="background-color: #0F6342; border-bottom-left-radius: 10px;">
@@ -151,7 +150,7 @@
 		<div th:if="${book.status == '貸出中' && screenFlag != 2}">
 		  <form id="return-form-main" method="post" class="d-inline">
 		    <input type="hidden" name="bookId" th:value="${book.bookId}"/>
-		    <button id="rc" type="button" class="btn btn-lg col-5 col-sm-4 fs-6 shadow" style="color: #47B78A">
+		    <button id="rc" type="button" class="btn btn-lg col-5 col-sm-4 shadow" style="color: #47B78A; font-size: 18px">
 		      返す
 		    </button>
 		  </form>


### PR DESCRIPTION
# 概要
- バグチケットINC0022の修正およびSearchRusultのボタンのフォントサイズ統一

## 作業内容
- AWS環境において返却コメントのバリデーションチェックのバグ修正
- SearchRusultの借りる/返すボタンのフォントサイズを18pxに統一

# 変更理由
- クリティカルなバグのため優先的に対応

## 確認事項
- [ ] 感想・コメントが記入されていない状態で「返す」ボタンを押下すると同じ画面が表示され、エラーメッセージが表示されることを確認
- [ ] SearchRusultの借りる/返すボタンのフォントサイズが18pxに統一されていること

## 備考
- 不要なインポート文を削除