### PR TITLE
fix: 未ログイン時ヘッダーにログアウト非表示修正およびタイトル押下時TOPに遷移修正

### DIFF
--- a/InternalBooks/src/main/resources/templates/layout/header.html
+++ b/InternalBooks/src/main/resources/templates/layout/header.html
@@ -3,7 +3,7 @@
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark" th:fragment="header">
     <div class="container-fluid">
-        <a class="navbar-brand" href="/">GrowLibrary</a>
+        <a class="navbar-brand" href="/page/top">GrowLibrary</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
                 data-bs-target="#navbarContent" aria-controls="navbarContent"
                 aria-expanded="false" aria-label="Toggle navigation">
@@ -17,7 +17,7 @@
 					<a class="nav-link active" aria-current="page" href="/page/categories">カテゴリー</a>
                 </li>
             </ul>
-			<a href="/" class="nav-link text-white d-flex align-items-center">
+			<a th:if="${session.token != null}" href="/" class="nav-link text-white d-flex align-items-center">
 				ログアウト 
 				<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-right" viewBox="0 0 16 16">
 				  <path fill-rule="evenodd" d="M10 12.5a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v2a.5.5 0 0 0 1 0v-2A1.5 1.5 0 0 0 9.5 2h-8A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-2a.5.5 0 0 0-1 0z"/>


### PR DESCRIPTION
# 概要
-未ログイン時ログアウト機能非表示

## 作業内容
- 条件式を追加し、未ログイン時ログアウト機能を非表示に修正
- タイトル押下時TOPに遷移するように修正 

# 変更理由
- 経営層レビューの指摘内容

## 確認事項
- 未ログイン時ログアウトが表示されないこと
- ログイン後ログアウトが表示されること
- タイトル押下時TOPに遷移できること  

## 備考
- 特になし