### PR TITLE
feat: 二重処理防止フラグ追加

### DIFF
--- a/InternalBooks/src/main/java/com/example/internalbooks/common/Const.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/common/Const.java
@@ -45,5 +45,8 @@ public class Const {
 	 */
 	public static final int DELETE_FLAG_OFF = 0;
 	public static final int DELETE_FLAG_ON = 1;
+	
+	
+	public static final String RETURN_COMPLETED_FLAG = "RETURN_COMPLETED_FLAG";
 
 }

--- a/InternalBooks/src/main/java/com/example/internalbooks/controller/InternalBooksController.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/controller/InternalBooksController.java
@@ -2,9 +2,6 @@ package com.example.internalbooks.controller;
 
 import java.util.List;
 
-import jakarta.servlet.http.HttpSession;
-import jakarta.validation.Valid;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +27,8 @@ import com.example.internalbooks.service.TBookService;
 import com.example.internalbooks.service.TLendingHistoryService;
 import com.example.internalbooks.utils.JwtUtil;
 
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 
 @Controller
@@ -180,6 +179,8 @@ public class InternalBooksController {
 
             // 貸出中書籍からの遷移フラグをセッションに設定
             session.setAttribute("screenFlag", screenFlag);
+            //古川追記：ブラウザバックによる二重返却を防止するフラグを設定
+            session.setAttribute(Const. RETURN_COMPLETED_FLAG,true);
 
             return "page/checkedout";
         } catch (Exception e) {
@@ -315,8 +316,8 @@ public class InternalBooksController {
             model.addAttribute("book", book);
             model.addAttribute("categories", book.getCategories());
 
-            // 書籍履歴を取得
-            List<DtoBookHistory> dtoBookHistory;
+        	// 書籍履歴を取得
+        	List<DtoBookHistory> dtoBookHistory;
 
             if (bookId == null && qrData != null) {
                 // QRコードから遷移した場合
@@ -433,7 +434,25 @@ public class InternalBooksController {
             Model model,
             RedirectAttributes redirectAttributes) {
 
+    	
         try {
+        	
+        	System.out.println(
+        		    session.getAttribute("RETURN_COMPLETED_FLAG")
+        		);
+
+        		System.out.println(
+        		    session.getAttribute(Const.RETURN_COMPLETED_FLAG)
+        		);
+        	
+        	
+        	//古川追記：ブラウザバック後の再送信などで同じ返却処理が再実行されることを防ぐ
+        	// 二重返却防止処理
+        	if (session.getAttribute(Const. RETURN_COMPLETED_FLAG) == null) {
+        	    redirectAttributes.addFlashAttribute("errorMessage","この書籍はすでに返却処理されています。");
+        	    return "redirect:/page/top";
+        	}
+        	
             // torkenの検証
             String token = (String) session.getAttribute("token");
             Integer userId = jwtUtil.extractUserId(token);
@@ -482,6 +501,10 @@ public class InternalBooksController {
 
             // DBへ(userId,name,mailAddress,password,departmentId)を保存
             TLendingHistoryEntity savedLend = lendingHistoryService.returnCompleted(dtlend);
+            
+
+            
+            
             // DBに保存した値をDTOを経由して再度取得
             DtoBookHistoryRegistration tlend = new DtoBookHistoryRegistration();
             tlend.setBookId(savedLend.getBookId());
@@ -519,6 +542,10 @@ public class InternalBooksController {
             }
 
             redirectAttributes.addAttribute("bookId", bookId);
+            
+            //古川追記：ブラウザバックによる二重返却を防止するフラグを削除
+            session.removeAttribute(Const. RETURN_COMPLETED_FLAG);
+            
             return "redirect:/page/ReturnCompleted";
         } catch (Exception e) {
             return error(redirectAttributes);
@@ -632,7 +659,11 @@ public class InternalBooksController {
                 return "redirect:/page/top";
             }
 
+            
+
+            
             return "page/ReturnCompleted";
+            
         } catch (Exception e) {
             return error(redirectAttributes);
         }

--- a/InternalBooks/src/main/java/com/example/internalbooks/controller/InternalBooksController.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/controller/InternalBooksController.java
@@ -435,16 +435,7 @@ public class InternalBooksController {
             RedirectAttributes redirectAttributes) {
 
     	
-        try {
-        	
-        	System.out.println(
-        		    session.getAttribute("RETURN_COMPLETED_FLAG")
-        		);
-
-        		System.out.println(
-        		    session.getAttribute(Const.RETURN_COMPLETED_FLAG)
-        		);
-        	
+        try {	
         	
         	//古川追記：ブラウザバック後の再送信などで同じ返却処理が再実行されることを防ぐ
         	// 二重返却防止処理


### PR DESCRIPTION
# 概要
- 返却処理の二重実行を防止するための改修を実施

## 作業内容
- 返却処理中であることを管理するフラグを追加
- 返却処理実行時にフラグを判定する処理を追加
- 返却処理完了後にフラグを削除する処理を追加

# 変更理由
- ブラウザバックなどにより返却処理が再実行されると、返却済みの書籍に対して再度返却処理が実行できてしまう問題があったため

## 確認事項
- 返却完了後にブラウザバックを行い、再度返却処理を実行しようとした際にトップページへ遷移すること
- ブラウザバックでトップページまで戻った後、「返す」ボタンを押下しても返却済みの書籍が表示されないこと

## 備考
- 画面上でエラーメッセージの表示を指せる処理は未実装