### PR TITLE
feat: SerchResultの呼び出し元によって検索結果詳細ページのタイトルの表示が変わるようにしました。(INC0027)

### DIFF
--- a/InternalBooks/src/main/resources/templates/page/SearchResult.html
+++ b/InternalBooks/src/main/resources/templates/page/SearchResult.html
@@ -11,7 +11,11 @@
 
     <!-- ================== ページメインタイトル ================== -->
     <div class="container-sm text-center mt-4">
-  		<h1 class="fw-bold mt-4 display-4 mb-4">検索結果詳細</h1>
+  		<h1 class="fw-bold mt-4 display-4 mb-4" th:switch="${screenFlag}">
+			<span th:case="1">本の詳細</span>
+			<span th:case="2">本を借りる</span>
+			<span th:case="3">本を返す</span>
+		</h1>
     </div>
 
     <!-- ================== 書籍情報がない場合の表示 ================== -->


### PR DESCRIPTION
# 概要
- 【INC0027】SeqrchResultの呼び出し元によってタイトルを変更


## 作業内容
- screenFlagの値によってSearchResultに表示されるタイトルを変更した。
- screenFlag = 1　「本の詳細」（カテゴリー一覧より遷移）
- screenFlag = 2　「本を借りる」（借りる画面より遷移）
- screenFlag = 3　「本を返す」（返す画面より遷移）

# 変更理由
-  serchresultに遷移したとき、借りる・返す・カテゴリーどこから遷移したからわからないため

## 確認事項
- 「借りる」「返す」「カテゴリーで検索」それぞれのボタンから遷移した際の 書籍詳細ページのタイトルを確認

## 備考
- 				
				
				
				
				
				
				
				
				
				
				