### PR TITLE
【INC0032】DBの書籍提供者がnullの場合、グロウ　太郎と表示 されるようにする

### DIFF
--- a/InternalBooks/src/main/java/com/example/internalbooks/common/Const.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/common/Const.java
@@ -18,6 +18,7 @@ public class Const {
 	public final static String CATEGORIES = "categories";
 	public final static String BORROWER_ID = "borrower_id";
 	public final static String PROVIDER_ID = "provider_id";
+	public final static String COMMON_PROVIDER_NAME = "グロウ太郎";
 
 	public final static String PROVIDER_COMMENT = "provider_comment";
 	public final static String MEMO = "memo";

--- a/InternalBooks/src/main/java/com/example/internalbooks/common/Const.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/common/Const.java
@@ -18,7 +18,7 @@ public class Const {
 	public final static String CATEGORIES = "categories";
 	public final static String BORROWER_ID = "borrower_id";
 	public final static String PROVIDER_ID = "provider_id";
-	public final static String COMMON_PROVIDER_NAME = "グロウ太郎";
+	public final static String COMMON_PROVIDER_NAME = "グロウ 太郎";
 
 	public final static String PROVIDER_COMMENT = "provider_comment";
 	public final static String MEMO = "memo";

--- a/InternalBooks/src/main/java/com/example/internalbooks/service/TBookService.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/service/TBookService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.example.internalbooks.common.Const;
 import com.example.internalbooks.dto.DtoBookInfo;
 import com.example.internalbooks.entity.TBookEntity;
 import com.example.internalbooks.entity.TLendingHistoryEntity;
@@ -22,7 +23,6 @@ import com.example.internalbooks.entity.TUserEntity;
 import com.example.internalbooks.repository.TBookRepository;
 import com.example.internalbooks.repository.TLendingHistoryRepository;
 import com.example.internalbooks.repository.TUserRepository;
-import com.example.internalbooks.common.Const;
 
 @Service
 @Transactional
@@ -186,15 +186,16 @@ public class TBookService {
 
 		// 書籍提供者名を取得して設定
 		if (book.getProviderId() != null) {
-			try {
-				TUserEntity provider = tUserService.getUserById(book.getProviderId());
-				if (provider != null) {
-					dto.setProviderName(provider.getName());
-				}
-			} catch (Exception e) {
-				// ユーザーが見つからない場合はnullのまま
-				dto.setProviderName(null);
+			TUserEntity provider = tUserService.getUserById(book.getProviderId());
+			if (provider != null) {
+				dto.setProviderName(provider.getName());
+			} else {
+			// ユーザーが見つからない場合はグロウ太郎と表示
+			dto.setProviderName(Const.COMMON_PROVIDER_NAME);
 			}
+		} else {
+			// providerIdがnullの場合もグロウ太郎と表示
+			dto.setProviderName(Const.COMMON_PROVIDER_NAME);
 		}
 
 		// 返却 感想・コメント

--- a/InternalBooks/src/main/java/com/example/internalbooks/service/TBookService.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/service/TBookService.java
@@ -187,14 +187,9 @@ public class TBookService {
 		// 書籍提供者名を取得して設定
 		if (book.getProviderId() != null) {
 			TUserEntity provider = tUserService.getUserById(book.getProviderId());
-			if (provider != null) {
-				dto.setProviderName(provider.getName());
-			} else {
-			// ユーザーが見つからない場合はグロウ太郎と表示
-			dto.setProviderName(Const.COMMON_PROVIDER_NAME);
-			}
+			dto.setProviderName(provider.getName());
 		} else {
-			// providerIdがnullの場合もグロウ太郎と表示
+			// providerIdがnullの場合「グロウ　太郎」と表示
 			dto.setProviderName(Const.COMMON_PROVIDER_NAME);
 		}
 

--- a/InternalBooks/src/main/java/com/example/internalbooks/service/TUserService.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/service/TUserService.java
@@ -59,7 +59,7 @@ public class TUserService implements UserDetailsService {
 	 * @param userId ユーザID
 	 * @return ユーザ情報
 	 */
-	public TUserEntity getUserById(Integer userId) throws UsernameNotFoundException {
+	public TUserEntity getUserById(Integer userId) {
 		Optional<TUserEntity> user = tUserRepository.findById(userId); // メールでユーザーを検索
 		if (user.isEmpty()) {
 			return null;

--- a/InternalBooks/src/main/resources/templates/page/SearchResult.html
+++ b/InternalBooks/src/main/resources/templates/page/SearchResult.html
@@ -114,7 +114,7 @@
 	  	</div>
 
 	 <div class="row d-flex justify-content-center" th:if="${book.status != '貸出中'}">
-	 	<p th:text="書籍提供者： + ${book.providerName}" class="col-11 col-sm-8 mb-1">書籍提供者：グロウ太郎</p>
+	 	<p th:text="書籍提供者： + ${book.providerName}" class="col-11 col-sm-8 mb-1">書籍提供者：グロウ 太郎</p>
 	 	<p th:text="${book.providerComment}" class="col-11 col-sm-8 p-3" style="background-color: #E8ECE8; border-radius: 10px;">
 			書籍提供者コメント
 			この文章はダミーです。文字の大きさ、量、字間、行間等を確認するために入れています。

--- a/InternalBooks/src/main/resources/templates/page/SearchResult.html
+++ b/InternalBooks/src/main/resources/templates/page/SearchResult.html
@@ -114,7 +114,7 @@
 	  	</div>
 
 	 <div class="row d-flex justify-content-center" th:if="${book.status != '貸出中'}">
-	 	<p th:text="書籍提供者： + ${book.providerName}" class="col-11 col-sm-8 mb-1">書籍提供者：武藤</p>
+	 	<p th:text="書籍提供者： + ${book.providerName}" class="col-11 col-sm-8 mb-1">書籍提供者：グロウ太郎</p>
 	 	<p th:text="${book.providerComment}" class="col-11 col-sm-8 p-3" style="background-color: #E8ECE8; border-radius: 10px;">
 			書籍提供者コメント
 			この文章はダミーです。文字の大きさ、量、字間、行間等を確認するために入れています。


### PR DESCRIPTION
# 概要
t_book（DB）のprovider_idがnullの場合に書籍提供者が「グロウ　太郎」と表示されるようにする。

## 作業内容
- provider_idがnullの場合にConstクラスの定数COMMON_PROVIDER_NAMEを用いて「グロウ　太郎」と表示されるよう修正（TBookService内のconvertEntityToDto）
- provider_idが存在する場合でもユーザーが見つからない場合も「グロウ　太郎」と表示
- 「グロウ　太郎」という定数を使用するためConstクラスに定数COMMON_PROVIDER_NAME=グロウ　太郎を追加
- SearchResult.html内でthymeleafが動作しなかった場合に書籍提供者が「グロウ　太郎」と表示されるように修正

# 変更理由
- 書籍提供者がnullと表示されると見た目上さみしいため

## 確認事項
- [   ]  DBのprovider_idがnullの場合に書籍提供者が「グロウ　太郎」と表示されることを確認

## 備考
- t_userのカラム名nameの形式にあわせ、苗字と名前の間に全角スペースを挿入