### PR TITLE
fix: 【INC0020】返却コメントが255文字を超過した場合エラーページへ遷移

### DIFF
--- a/InternalBooks/src/main/java/com/example/internalbooks/dto/DtoBookHistoryRegistration.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/dto/DtoBookHistoryRegistration.java
@@ -3,6 +3,7 @@ package com.example.internalbooks.dto;
 import java.time.LocalDateTime;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import lombok.Data;
 
@@ -28,5 +29,8 @@ public class DtoBookHistoryRegistration {
 
 	// レビュー
 	@NotBlank(message = "感想を記入してください")
+	@Size(max = 255, message = "感想は255文字以内で入力してください")
 	private String review;
+	
+	
 }

--- a/InternalBooks/src/main/resources/templates/page/SearchResult.html
+++ b/InternalBooks/src/main/resources/templates/page/SearchResult.html
@@ -133,7 +133,11 @@
 			</div>
 			<textarea id="comment" class="col-11 col-sm-8 ps-2" th:field="*{review}"
 		 			  placeholder="こちらに感想やコメントを記入してください。︎︎︎" 
-					  style="background-color: #E8ECE8; border-radius: 10px; border: 0px none;;"></textarea>
+					  style="background-color: #E8ECE8; border-radius: 10px; border: 0px none;;">
+			</textarea>
+			<div class="col-11 col-sm-8 text-end">
+				<span id="charCount">0</span>/255文字
+			</div>
 		</div>
 	</form>
 
@@ -208,7 +212,8 @@
 			<!-- ========== 感想表示 ========== -->
 			<div th:if="${!#strings.isEmpty(history.review)}"
 				 class="d-flex flex-column justify-content-center shadow col-11 col-sm-8 mb-4" style="background-color: #E5EAE5; border-radius: 10px;">
-				<p th:text="${history.review}" class="col-12 mt-2 mb-0">感想</p>
+				<p th:text="${history.review}" class="col-12 mt-2 mb-0"
+				   style="white-space: pre-wrap; overflow-wrap: break-word;">感想</p>
 				<div class="d-flex mt-3 justify-content-end me-4">
 					<p th:text="${history.userName}" class="me-3">武藤</p>
 					<p th:text="${history.returnDate}" class="">2026年1月1日</p>
@@ -337,6 +342,22 @@
 	};
 
 	document.addEventListener("DOMContentLoaded", adjustHeight);
+	
+	document.addEventListener('DOMContentLoaded', function() {
+	    const textarea = document.getElementById('comment');
+	    const charCount = document.getElementById('charCount');
+
+	    function updateCount() {
+	        charCount.textContent = textarea.value.length;
+			if (textarea.value.length > 255) {
+				charCount.classList.add('text-danger');
+			} else {
+				charCount.classList.remove('text-danger');
+			}
+	    }
+	    textarea.addEventListener('input', updateCount);
+	    updateCount(); // 初期表示
+	});
 	
   </script>
   </section>


### PR DESCRIPTION
# 概要
INC0020：返却コメントが255文字を超過した場合エラーページへ遷移

## 作業内容
- DtoBookHistoryRegistrationクラスのフィールド変数reviewに`@Size(max = 255)`を追加（DtoBookHistoryRegistration,java : L32）
  - 255文字を超過した状態で送信をクリックしても、「感想は255文字以内で入力してください」というメッセージとともに再入力を求める
- 返却コメント入力欄に文字数カウント機能を追加（SearchResult.html : L346~360）
- 上記の文字数カウントが255文字を超過した場合に入力エラーであることが分かるよう、文字数表示を赤字に変更（SearchResult.html : L352~356）

# 変更理由
### DBエラーを起こすとセッションエラーが発生し、ログイン画面に遷移するのを防ぐため
-  DBの t_lendinghistory.review カラムはVARCHAR(255)で定義されているため、255文字を超える入力時にDBエラーが発生していた。
- 対策としてDB上の文字数制限（255文字）に合わせて、reviewフィールドにバリデーションを追加した
### フロントサイドで送信前に超過に気づけるようにするため
- サーバーサイドで255文字のバリデーションを追加したことに合わせて、フロント側でも入力文字数を確認できるように文字数カウントを追加することによってユーザーが送信前に入力内容を修正できるようにした。

## 確認事項
- [ ] 借りている書籍を返却する際に感想入力欄右下に文字数カウントが存在している
- [ ] 文字数カウントがリアルタイムで正しく動作している
- [ ] 文字数カウントが255文字を超えた際に赤字に変化する
- [ ] 255文字を超過した状態で送信すると「感想は255文字以内で入力してください」というメッセージとともに元の画面に遷移する

## 備考
- DtoBookHistoryRegistrationクラスのフィールド変数reviewに`@NotBlank`バリデーションがもともと存在したため参考
- フロント側で`maxlength="255"`によって、255文字以降の入力を阻止することも考えたが、感想をたくさん書きたいユーザーはたくさん書いてから添削する形をとるのではと考えたためここには入力制限を設けなかった
