### PR TITLE
fix: 【INC0003】貸出中書籍のアクセス制御対応

### DIFF
--- a/InternalBooks/src/main/java/com/example/internalbooks/controller/AdminController.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/controller/AdminController.java
@@ -325,6 +325,10 @@ public class AdminController extends InternalBooksController {
 
             // bookIdに基づいて書籍情報を取得
             DtoBookInfo bookInfo = tBookService.getBookById(bookId);
+            if ("貸出中".equals(bookInfo.getStatus())){
+            	redirectAttributes.addFlashAttribute("error", "貸出中の書籍は削除できません");
+				return "redirect:/admin/bookdeletingcategories";
+            }
             model.addAttribute("bookInfo", bookInfo);
 
             // セッションからカテゴリーを取得

--- a/InternalBooks/src/main/java/com/example/internalbooks/controller/InternalBooksController.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/controller/InternalBooksController.java
@@ -2,6 +2,9 @@ package com.example.internalbooks.controller;
 
 import java.util.List;
 
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,8 +30,6 @@ import com.example.internalbooks.service.TBookService;
 import com.example.internalbooks.service.TLendingHistoryService;
 import com.example.internalbooks.utils.JwtUtil;
 
-import jakarta.servlet.http.HttpSession;
-import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 
 @Controller
@@ -312,6 +313,15 @@ public class InternalBooksController {
                 }
                 redirectAttributes.addFlashAttribute("error", "書籍が取得できませんでした");
                 return "redirect:/page/top";
+            }
+            
+            // 貸出中書籍にはアクセスできないように制御
+            Integer longinUserId = validateTokenAndGetUserId(session);
+            if ("貸出中".equals(book.getStatus())) {
+	            if (!tBookService.isBookBorrowedByUser(book.getBookId(), longinUserId)) {
+					redirectAttributes.addFlashAttribute("error", "この書籍は貸出中のためアクセスできません");
+					return "redirect:/page/top";
+				}
             }
             model.addAttribute("book", book);
             model.addAttribute("categories", book.getCategories());

--- a/InternalBooks/src/main/java/com/example/internalbooks/controller/InternalBooksController.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/controller/InternalBooksController.java
@@ -316,9 +316,9 @@ public class InternalBooksController {
             }
             
             // 貸出中書籍にはアクセスできないように制御
-            Integer longinUserId = validateTokenAndGetUserId(session);
+            Integer loginUserId = validateTokenAndGetUserId(session);
             if ("貸出中".equals(book.getStatus())) {
-	            if (!tBookService.isBookBorrowedByUser(book.getBookId(), longinUserId)) {
+	            if (!tBookService.isBookBorrowedByUser(book.getBookId(), loginUserId)) {
 					redirectAttributes.addFlashAttribute("error", "この書籍は貸出中のためアクセスできません");
 					return "redirect:/page/top";
 				}

--- a/InternalBooks/src/main/java/com/example/internalbooks/service/TBookService.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/service/TBookService.java
@@ -325,6 +325,18 @@ public class TBookService {
 		}
 		return "貸出可能";
 	}
+	
+	
+	/**
+	 * 指定された書籍IDが指定されたユーザーIDによって借りられているかを確認するメソッド
+	 */
+	public boolean isBookBorrowedByUser(Integer bookId, Integer userId) {
+		TBookEntity bookEntity = tBookRepository.findById(bookId).orElse(null);
+		if (bookEntity == null) {
+			return false;
+		}
+		return userId.equals(bookEntity.getBorrowerId());
+	}
 
 	/**
 	 * 書籍画像を処理するメソッド

--- a/InternalBooks/src/main/java/com/example/internalbooks/service/TBookService.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/service/TBookService.java
@@ -335,7 +335,18 @@ public class TBookService {
 		if (bookEntity == null) {
 			return false;
 		}
-		return userId.equals(bookEntity.getBorrowerId());
+		if (bookEntity.getBorrowerId() != null) {
+			return userId.equals(bookEntity.getBorrowerId());
+		}
+		// borrowerIdがnullでも、履歴テーブル上で未返却のなら借用者を判定（データ不整合への対抗策）
+		List<TLendingHistoryEntity> histories = lendingHistoryRepository.findByBookId(bookId);
+		if (!histories.isEmpty()) {
+			TLendingHistoryEntity latest = histories.get(0);
+			if (latest.getReturnDate() == null) {
+				return userId.equals(latest.getUserId());
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/InternalBooks/src/main/resources/templates/page/bookdeletingcategories.html
+++ b/InternalBooks/src/main/resources/templates/page/bookdeletingcategories.html
@@ -10,7 +10,10 @@
 		<div class="container d-flex justify-content-center align-items-center">
 			<div class="w-100" style="max-width: 400px;">
 				<h1 class="mb-4 text-center">カテゴリー</h1>
-
+				<!-- エラー表示エリア -->
+				<div class="alert alert-danger text-center" th:if="${error}" role="alert">
+                    <span th:text="${error}"></span>
+				</div>
 
 				<!--2列レイアウト -->
 				<div class="row g-3">

--- a/InternalBooks/src/main/resources/templates/page/top.html
+++ b/InternalBooks/src/main/resources/templates/page/top.html
@@ -18,7 +18,13 @@
     	        <div class="" style="width: 330px;">
 <!--            <div class="w-100" style="max-width: 330px;">-->
         	        <h1 class="mb-4 text-center">Top</h1>
-
+					
+					<!-- エラー表示エリア -->
+					<div class="alert alert-danger text-center" th:if="${error}" role="alert">
+						<h6 class="mb-1 fw-bold">エラーが発生しました</h6>
+					    <div th:text="${error}"></div>
+					</div>
+					
                 	<!-- ボタンを縦に並べ、中央に配置 -->
                 	    <div class="d-flex justify-content-between mb-3">
                         <!-- 正方形ボタン（借りる） -->


### PR DESCRIPTION
# 概要
INC0003：貸出中書籍のアクセス制御対応
bookIdをクエリパラメータに直接渡すことによって、アクセスできないはずの貸出中書籍にアクセスできてしまう

## 作業内容
- TBookServiceクラスにisBookBorrowedByUserメソッドを追加（TBookService.java  : L330~339）
  - 引数にbookIdとuserIdを持ち、与えられたbookIdで検索された書籍のborrowerIdとuserIdを比較し、等しい場合trueを返却する
  
 - InternalBooksControllerクラスのsearchResultメソッドにアクセス制御機能を追加（InternalBooksController.java : L318~325）
   - 書籍のステータスが「貸出中」の場合、セッションから取得したユーザーIDと書籍のborrowerIdを上記のisBookBorrowedByUserメソッドによって比較
   - 一致する場合はアクセス許可。一致しない場合はエラーメッセージとともにトップページにリダイレクト
 
- AdminControllerクラスのbookdeletingconfirmarionメソッドにアクセス制御機能を追加（AdminController.java : L328~331）
  - 書籍のステータスが「貸出中」の場合、アクセス阻止→エラーメッセージとともにカテゴリーページにリダイレクト

- トップページにエラーメッセージ領域を作成（top.html : L22~26）
  - リダイレクトした際に`th:text`を利用し、「この書籍は貸出中のためアクセスできません」というエラーメッセージを表示
 
- 管理者書籍削除対象カテゴリー画面にエラーメッセージ領域を作成（bookdeletingcategories.html : L13~16）
  - リダイレクトした際に`th:text`を利用し、「貸出中の書籍は削除できません」というエラーメッセージを表示

# 変更理由
### 書籍アクセス制御によってクエリパラメータをいじって他の貸出中書籍にアクセスできなくするため
-  ログインユーザーIDと対象の書籍を借りているユーザーIDを比較することによって他のユーザーが借りている書籍にアクセスできないようにした。
- screenFlagで判断することも考えたが、セキュリティの関係上ログインユーザーで判断することが安全だと考えた。
- ユーザーIDの比較はService側で行うのが最も適切だと考えたため、Controller側の制御をしないこととした。
- リダイレクトする際に何もメッセージがないとユーザー側がどういった行動をしてしまったのか理解できないためエラーメッセージの表記を行うこととした。

## 確認事項
- [ ] クエリパラメータをいじった際にログインユーザー以外が借りている書籍にアクセスできない（serchResult側）
- [ ] 上記でリダイレクトした場合、トップページにエラーメッセージが表示される（top側）
- [ ] クエリパラメータをいじった際に貸出中書籍にアクセスできない（bookdeletingcategories側）
- [ ] 上記でリダイレクトした場合、削除対象カテゴリーページにエラーメッセージが表示される（bookdeletingcategories側）

## 備考
なし