### PR TITLE
fix: 【INC0035】AWS上で曜日を日本語表記に統一

### DIFF
--- a/InternalBooks/src/main/java/com/example/internalbooks/service/TBookService.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/service/TBookService.java
@@ -5,6 +5,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -217,7 +218,7 @@ public class TBookService {
 		if (!histories.isEmpty()) {
 			TLendingHistoryEntity latestHistory = histories.get(0);
 			if (latestHistory.getScheduledReturnDate() != null) {
-				DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy年MM月dd日(E)");
+				DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy年MM月dd日(E)", Locale.JAPAN);
 				dto.setScheduledReturnDate(latestHistory.getScheduledReturnDate().format(formatter));
 			} else {
 				dto.setScheduledReturnDate("-");

--- a/InternalBooks/src/main/java/com/example/internalbooks/service/TLendingHistoryService.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/service/TLendingHistoryService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,7 +39,7 @@ public class TLendingHistoryService {
         List<DtoBookHistory> dtoList = new ArrayList<>();
         for (TLendingHistoryEntity e : entities) {
             DtoBookHistory dto = new DtoBookHistory();
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy年MM月dd日(E)");
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy年MM月dd日(E)", Locale.JAPAN);
             dto.setLendingDate(
                     e.getLendingDate() != null ? e.getLendingDate().format(formatter) : "-");
             dto.setScheduledReturnDate(
@@ -121,7 +122,7 @@ public class TLendingHistoryService {
      */
     public List<DtoBookHistory> getScheduledReturnDatesByBookIds(List<Integer> bookIds) {
         List<DtoBookHistory> bookHistoryList = new ArrayList<>();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy年MM月dd日(E)");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy年MM月dd日(E)", Locale.JAPAN);
 
         for (Integer bookId : bookIds) {
             DtoBookHistory history = new DtoBookHistory();


### PR DESCRIPTION
# 概要
### INC0035：AWS上で曜日を日本語表記に統一
AWS上で曜日表記すると英語表記になってしまう。

## 作業内容
- `java.util.Locale`をインポート（TBookService.java : L8, TLendingHistoryService.java : L7）
- `DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy年MM月dd日(E)");`を`DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy年MM月dd日(E)", Locale.JAPAN);`に変更（TBookService.java : L221, TLendingService.java : L42,125）
  - `Local`で強制的に日本語表記に変更

# 変更理由
### AWS上で日本語表記に統一するため
- ローカル上では日本語表記だが、AWS本番環境では曜日が英語表記になってしまう。
- 日本語に変更した方が見栄えがいいため

## 確認事項
- [ ] 本番環境で曜日が日本語表記になっている。

## 備考
- gradleに下記を追加し、bootrunで実行することによってUS環境を再現
``` 
tasks.named('bootRun') {
	jvmArgs = [
		'-Duser.language=en',
		'-Duser.country=US',
		'-Duser.timezone=UTC'
	]
 }
```

[修正前]
<img width="1920" height="1080" alt="修正前" src="https://github.com/user-attachments/assets/77830471-a42a-486b-963e-8b56a886e5ec" />

[修正後]
<img width="1920" height="1080" alt="修正後" src="https://github.com/user-attachments/assets/fe7aa7a7-d817-4aa1-8431-4fc5fe7cd6ec" />



