### PR TITLE
fix: 【INC0041】JWT二重デコードの修正

### DIFF
--- a/InternalBooks/src/main/java/com/example/internalbooks/controller/InternalBooksController.java
+++ b/InternalBooks/src/main/java/com/example/internalbooks/controller/InternalBooksController.java
@@ -263,7 +263,7 @@ public class InternalBooksController {
 
         try {
             // JWT認証トークンの検証（共通メソッド）
-            validateTokenAndGetUserId(session);
+            Integer loginUserId = validateTokenAndGetUserId(session);
 
             model.addAttribute("bookdto", new DtoBookHistoryRegistration());
 
@@ -316,7 +316,6 @@ public class InternalBooksController {
             }
             
             // 貸出中書籍にはアクセスできないように制御
-            Integer loginUserId = validateTokenAndGetUserId(session);
             if ("貸出中".equals(book.getStatus())) {
 	            if (!tBookService.isBookBorrowedByUser(book.getBookId(), loginUserId)) {
 					redirectAttributes.addFlashAttribute("error", "この書籍は貸出中のためアクセスできません");


### PR DESCRIPTION
# 概要
### INC0041：JWT二重デコードの修正
JWTを一つの変数にまとめて利用する

## 作業内容
InternalBooksController.searchResultのJWTを`Integer loginUserId = validateTokenAndGetUserId(session);`としてまとめる（InternalBooksController : L266, 319）

# 変更理由
### 冗長となってしまっているため
- ひとつにまとめることでメンテナンスが容易になる

## 確認事項
- [ ] ログインユーザー以外が借りている本にアクセスできない

## 備考
なし

